### PR TITLE
Add note about setting base directory in Netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ In the meantime it's possible to add bookmarklets to [Chrome on Android](https:/
 
 ## Self-hosted
 
-The most secure way to use `send-to-workflowy` is to host it yourself. This repository can be deployed to Netlify with the following URL.
+The most secure way to use `send-to-workflowy` is to host it yourself. This repository can be deployed to Netlify with button below.
+
+You'll need to set the "Base directory" in Netlify's settings to `app`.
 
 The environment variables `SESSIONID` and `PARENTID` can be configured in the Netlify configuration to avoid the need to provide these to the web application in the browser.
 


### PR DESCRIPTION
I couldn't get the self-hosted version to work until I set the "Base directory" in Netlify to `app`, so I thought I'd add a note to the README to save someone else some time. 

![image](https://user-images.githubusercontent.com/15148/147488558-e06a77d8-79cf-4929-be3f-77c9ae78baf3.png)

Side note: I have been wishing for something like this for ages and I am beyond excited that you have made this available! Thank you thank you thank you!